### PR TITLE
Fix Sane-ui flickity dependency in sage9 projects

### DIFF
--- a/js/core.js
+++ b/js/core.js
@@ -62,7 +62,7 @@ function Flickity( element, options ) {
     this.$element = jQuery( this.element );
   }
   // options
-  this.options = { ...this.constructor.defaults };
+  this.options = Object.assign({}, this.constructor.defaults);
   this.option( options );
 
   // kick things off


### PR DESCRIPTION
Replaced spread operator with Object.assign for better compatibility with Sage 9.